### PR TITLE
Fixation of element width for unresponsive state [Optional change of plugin CSS]

### DIFF
--- a/src/main/css/seqrShop.css
+++ b/src/main/css/seqrShop.css
@@ -14,7 +14,7 @@
 }
 #seqr-container {
   background: #f2f2f2;
-  max-width: 500px;
+  width: 500px;
   font-family: "SEQR", Helvetica, Arial, sans-serif;
   overflow: auto;
 }


### PR DESCRIPTION
When window larger than 600px; #seqr-container container have variable width but not responsive layout. By this reason in case when it placed in element with `work width` less than 500px it looks ugly.

Better solution to add some css classes which will provide possibility to use web element with different layout: as example if we want to place SEQR element on left side column which have 400px, it should looks like element on screen with width less than 600px, If site haven't responsive layout element should'n be responsive as well.    
